### PR TITLE
Fix rtp status vector erase logic.

### DIFF
--- a/src/voip_patrol/action.cc
+++ b/src/voip_patrol/action.cc
@@ -530,8 +530,9 @@ void Action::do_wait(vector<ActionParam> &params) {
 				test->update_result();
 				config->tests_with_rtp_stats.erase(config->tests_with_rtp_stats.begin()+pos);
 				LOG(logINFO) << __FUNCTION__ << " erase pos:" << pos;
+			} else {
 				pos++;
-			}
+ 			}
 		}
 
 		if (tests_running > 0) {


### PR DESCRIPTION
When some index is erased from vector, pos variable will point to
a removed entry.

pseudo code:
```
x = [1,2,3,4,5]
while length(x) {
    pos = 0;
    x.erase(x.begin()+pos); // -> [2,3,4,5]
    pos++;
}
```

if you loop with length and mutate vector inside the loop,
you'll mess your index (pos) variable.